### PR TITLE
fix nginx config to work with simple webpack-dev-server setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
   front:
     build:
       context: ./front
-    volumes:
-      - ./front:/app
+    # volumes:
+    #  - ./front:/app
     # ports:
     #   - "4568:4568"
 

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   devtool: "eval-source-map",
   devServer: {
     host: "0.0.0.0",
-    port: 4568,
+    port: 80,
     disableHostCheck: true,
     // allowedHosts: ["blackjack98.xyz", "localhost"],
     watchOptions: {

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -1,12 +1,19 @@
 upstream frontend {
-    server front:4568;
+  server front:80;
 }
+
 server {
-    listen 80;
-    location /front {
-        proxy_pass http://frontend;
-        proxy_http_version 1.1;
-	    proxy_set_header Upgrade $http_upgrade;
-	    proxy_set_header Connection "Upgrade";
-    }
+  listen 80;
+
+  location / {
+    proxy_pass http://frontend;
+  }
+
+  # webpack-dev-server
+  location /sockjs-node {
+    proxy_pass http://frontend;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+  }
 }


### PR DESCRIPTION
The reason why I moved frontend's port from 4568 to 80 is due to the hot reloading failing with webpack.config.js's 4568 port mapping (while nginx only accepts port 80).

Slowly starting to think that it might be better to abandon the docker/nginx setup. The original intent of this was to simultaneously start multiple services at once (with an added benefit of not needing to worry about CORS in server but that can be hardcoded on server-side only if environment is dev) easily. However it seems like it's causing more trouble